### PR TITLE
Added Certificate Ripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@
 ## Terminal
 
 - [Alacritty](https://github.com/jwilm/alacritty) - Cross-platform, GPU-accelerated terminal emulator. 👏
+- [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - A CLI tool to extract server certificates from a URL. 👏
 - [Fzf command-line fuzzy finder](https://github.com/junegunn/fzf) - General-purpose command-line fuzzy finder that makes searching in history way easier. 👏
 - [Hyper](https://github.com/zeit/hyper) - Terminal built on web technologies. 👏
 - [Kitty](https://github.com/kovidgoyal/kitty) - Fast, feature-rich, cross-platform, GPU based terminal. 👏


### PR DESCRIPTION
Certificate Ripper is a lightweight, easy-to-use CLI tool that allows developers and security engineers to extract and inspect SSL/TLS certificates from remote servers directly from the terminal — no browser or GUI required.

Working with certificates is a common task when debugging HTTPS connectivity issues, verifying certificate chains, or auditing expiry dates across environments. While tools like OpenSSL can do this, they require verbose and hard-to-remember commands. Certificate Ripper offers a simpler, more developer-friendly
experience with support for multiple export formats (PEM, PKCS12, and more)