### PR TITLE
Add qnote to Notes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
 - [Turtl](https://github.com/turtl/desktop) - Secure and collaborative notebook. 👏
 - [Obsidian](https://obsidian.md) - Powerful note-keeping in markdown with tons of plugins.
 - [Logseq](https://logseq.com/) - Note-keeping in markdown, very nice pdf functionallity and flashcards. 👏
+- [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad with Markdown, PDF export via Typst, OCR, and version history. Built with Tauri 2. Available on AUR. 👏
 
 ## Office
 


### PR DESCRIPTION
**qnote** is a minimal, open-source notepad for Linux built with Tauri 2 (Rust + TypeScript).

**Key features:**
- Markdown editing with live preview
- Real PDF export via Typst
- OCR support via Tesseract
- Automatic version history with snapshots
- Frameless window, dark/light themes
- Available on AUR

**Links:**
- GitHub: https://github.com/Omibranch/qnote
- AUR: https://aur.archlinux.org/packages/qnote