### PR TITLE
Add OpenTypeless

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@
 ## Utilities
 
 - [CrossMacro](https://github.com/alper-han/CrossMacro) - Cross-platform mouse and keyboard macro recorder, player, editor, and text expansion tool with Wayland and X11 support. 👏
+- [OpenTypeless](https://github.com/tover0314-w/opentypeless) - Cross-platform AI voice typing app that turns speech into polished text in any app. 👏
 
 ## Version Control
 


### PR DESCRIPTION
Adds OpenTypeless to the Utilities section.\n\nOpenTypeless is an open-source cross-platform AI voice typing app with Linux AppImage, deb, and rpm releases.