### PR TITLE
Add Nav0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 - [Edge](https://www.microsoftedgeinsider.com/en-us/download?platform=linux-deb) - Fast and secure browser by Microsoft.
 - [Firefox](https://www.mozilla.org/en-US/firefox/) - Fast, lightweight and powerfully private web browser.
 - [Midori](https://www.midori-browser.org/) - Lightweight, fast and free web browser.
+- [Nav0](https://nav0.org) - Minimal, privacy-focused web browser with zero telemetry or tracking. 👏
 - [Opera](https://www.opera.com) - Fast, secure, easy-to-use and free VPN.
 - [Tor](https://www.torproject.org/) - Contain everything you need to safely browse the internet.
 - [Vivaldi](https://vivaldi.com) - Powerful, personal and flexible browser.


### PR DESCRIPTION
Adds [Nav0](https://nav0.org) to the **Browser** section, alphabetically between Midori and Opera.

Nav0 is a minimal, privacy-focused, open-source (MIT) web browser available on Linux (plus macOS and Windows), with zero telemetry or tracking. Marked open source with 👏. Repo: https://github.com/nav0-org/nav0-browser

Disclosure: I'm the maintainer.